### PR TITLE
Added ethnologue command (take 2)

### DIFF
--- a/modules/ethnologue.py
+++ b/modules/ethnologue.py
@@ -112,7 +112,7 @@ def ethnologue(phenny, input):
             name, iso_code, where_spoken, num_speakers, language_status, url)
     elif len(iso) > 1:
         did_you_mean = ['{} ({})'.format(i, phenny.ethno_data[i]) for i in iso if len(i) == 3]
-        response = "Did you mean: " + ', '.join(did_you_mean) + "? Use iso639 code for better results."
+        response = "Try .iso639 for better results. Did you mean: " + ', '.join(did_you_mean) + "?"
     else:
         response = "That ISO code wasn't found. (Hint: use .iso639 for better results)"
 

--- a/modules/seen.py
+++ b/modules/seen.py
@@ -37,7 +37,7 @@ def f_note(self, origin, match, args):
             self.seen[origin.nick.lower()] = (origin.sender, time.time())
             self.seen.sync()
 
-    try: note(phenny, input)
+    try: note(self, origin, match, args)
     except Exception as e: print(e)
 f_note.rule = r'(.*)'
 f_note.priority = 'low'


### PR DESCRIPTION
[completes this GCI 2013 task](https://google-melange.appspot.com/gci/task/view/google/gci2013/4554769062428672)
Syntax: `.ethnologue <lg>`, where "lg" can be an ISO-639-3 code or partial language name. If there is more than one language for language name given, a "did you mean?" prompt is used instead.
A fix for `.seen` was also attempted.
