### PR TITLE
fixed no speakers in .eth

### DIFF
--- a/modules/ethnologue.py
+++ b/modules/ethnologue.py
@@ -68,9 +68,11 @@ def parse_num_speakers(s):
         if len(i) <= 3 or ',' in i:
             if i.replace(',', '').replace('.', '').isdigit():
                 hits.append(int(i.replace(',', '').replace('.', '')))
-    if 'ethnic population' in s.lower():
-        return shorten_num(hits[0])
-    return shorten_num(hits[-1])
+    if hits:
+        if 'ethnic population' in s.lower():
+            return shorten_num(hits[0])
+        return shorten_num(hits[-1])
+    return 'No primary'
 
 def ethnologue(phenny, input):
     """.ethnologue <lg> - gives ethnologue info from partial language name or iso639"""


### PR DESCRIPTION
If there are no speakers of a language (e.g. http://www.ethnologue.com/language/lat), .eth will crash with an ugly exception. Here is a fix
