### PR TITLE
Enable authoritative commands

### DIFF
--- a/modules/admin.py
+++ b/modules/admin.py
@@ -33,6 +33,22 @@ def upgrade(phenny, input):
     """Request remote upgrade using a cryptographic signature"""
     commit, signature = input.group(1), input.group(2)
 
+    # check if we have a cryptographic public key
+
+    if not os.path.isfile(os.path.expanduser('~/.phenny/id_rsa.pub')):
+        phenny.reply('This instance has no cryptographic public key.')
+        return
+
+    # limit input space
+
+    if not re.fullmatch('[0-9a-f]{40}', commit):
+        phenny.reply('Invalid format: commit hash')
+        return
+
+    if not re.fullmatch('[A-Za-z0-9+/=]{172}', signature):
+        phenny.reply('Invalid format: signature')
+        return
+
     # check cryptographic signature
 
     if not check_signature(['.upgrade', commit], signature):

--- a/ssh/gen-key.sh
+++ b/ssh/gen-key.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+rm -f ~/.phenny/id_rsa
+rm -f ~/.phenny/id_rsa.pub
+ssh-keygen -b 1024 -q -N '' -f ~/.phenny/id_rsa

--- a/ssh/sign-msg.sh
+++ b/ssh/sign-msg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+message="$*"
+echo -n "$message "
+openssl dgst -sign ~/.phenny/id_rsa <(echo "$message") | base64 -w 0
+echo

--- a/ssh/verify-msg.sh
+++ b/ssh/verify-msg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+message="${@:1:$#-1}"
+signature="${@: -1}"
+public_key="$(ssh-keygen -e -f ~/.phenny/id_rsa.pub -m PKCS8)"
+openssl dgst -verify <(echo "$public_key") -signature <(echo "$signature" | base64 -d) <(echo "$message")


### PR DESCRIPTION
Fixes #392

```
$ ls ssh
gen-key.sh  sign-msg.sh  verify-msg.sh
```

Setup:
```
$ ./ssh/gen-key.sh 
```

**Note:** begiak needs a copy of the `~/.phenny/id_rsa.pub` file generated.

Signing a command:
```
$ ./ssh/sign-msg.sh .upgrade e76f655a5a62fafe91792e139eaceb6c75659a0e
.upgrade e76f655a5a62fafe91792e139eaceb6c75659a0e RCb7xQFrHrUfVtx+MWnTplrpoq01pa0mVuVsrT1SYxEk6AvNkiTa0O+noAQd8zVYMgvgvwJJWeSa5IFuxbPx93JzTvcEPo2ApC71R+svWKbOkgn8dcWlTdXE0WLo9Q71XZ0h6MeAfTMkK0FdlRAXqt4atPo6RPgcoHVGG7k3gb0=
```