### PR TITLE
[git.py] git_channels: event -> repo

### DIFF
--- a/modules/git.py
+++ b/modules/git.py
@@ -207,7 +207,13 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
             if (event_types is not None) and (event not in event_types):
                 return [], []
 
-            channels = config.git_channels.get(event, channels)
+            if config.git_channels:
+                full_name = data['repository']['full_name']
+                channels = []
+
+                for key, value in config.git_channels.items():
+                    if fnmatch(full_name, key):
+                        channels = value
 
             if event == 'commit_comment':
                 commit = data['comment']['commit_id'][:7]
@@ -310,11 +316,8 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
             elif event == 'push':
                 pusher_name = data['pusher']['name']
 
-                try:
-                    if pusher_name in config.gitbots:
-                        return [], []
-                except:
-                    pass
+                if pusher_name in config.gitbots:
+                    return [], []
 
                 ref = data['ref'].split('/')[-1]
                 repo_fullname = data['repository']['full_name']

--- a/phenny
+++ b/phenny
@@ -126,6 +126,7 @@ def main(argv=None):
             'ipv6': False,
             'password': None,
             'githook_autostart': False,
+            'gitbots': [],
             'git_channels': {},
             'git_events': {},
         }


### PR DESCRIPTION
See https://github.com/apertium/phenny/pull/422#issuecomment-408887463 for reference.
`apertium/bootstrap` was renamed to `apertium/apertium-init`, right?

```
git_channels = {
    'apertium/*': ['#apertium'],
    'hfst/hfst': ['#hfst'],
    'jonorthwash/ud-annotatrix': ['#_u-dep'],
}
```

Optionally, change `hfst/hfst` to `hfst/*` or maybe `hfst/hfst-*`.