### PR TITLE
Include all modules in coverage report

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,7 +20,7 @@ logger = logging.getLogger('phenny')
 
 
 def all_modules(file):
-    modules = glob.glob(dirname(file)+"/*.py")
+    modules = glob.glob(dirname(file) + '/*.py')
     return [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
 
 __all__ = all_modules(__file__)

--- a/__init__.py
+++ b/__init__.py
@@ -7,14 +7,24 @@ Licensed under the Eiffel Forum License 2.
 http://inamidst.com/phenny/
 """
 
+import glob
 import logging
 import os
+from os.path import dirname, basename, isfile
 import signal
 import sys
 import threading
 import time
 
 logger = logging.getLogger('phenny')
+
+
+def all_modules(file):
+    modules = glob.glob(dirname(file)+"/*.py")
+    return [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+
+__all__ = all_modules(__file__)
+
 
 class Watcher(object): 
     # Cf. http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/496735

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,5 +1,9 @@
+from __init__ import all_modules
+__all__ = all_modules(__file__)
+
+
 def caseless_equal(str_a, str_b):
 	return str_a.casefold() == str_b.casefold()
 
 def caseless_list(str_list):
-	return list(map(str.casefold,str_list))
+	return list(map(str.casefold, str_list))

--- a/modules/test/test_coverage.py
+++ b/modules/test/test_coverage.py
@@ -1,0 +1,2 @@
+from . import *
+from modules import *

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 export NOSE_VERBOSE=2
 export NOSE_WITH_COVERAGE=1
-export NOSE_COVER_MIN_PERCENTAGE=60
+export NOSE_COVER_MIN_PERCENTAGE=50
 
 python3 -m nose --cover-erase


### PR DESCRIPTION
The `NOSE_COVER_INCLUSIVE` flag seems to misbehave, so I had to work around it.

```
Name                            Stmts   Miss  Cover
---------------------------------------------------
phenny/__init__.py                 63     41    35%
__init__/__init__.py               63     41    35%
bot.py                            213    164    23%
irc.py                            200     76    62%
metar.py                          175     66    62%
phenny/modules/__init__.py          6      1    83%
modules/__init__.py                 6      1    83%
modules/admin.py                   89     58    35%
modules/apertium_wiki.py           37      5    86%
modules/apertium_wikistats.py      79     59    25%
modules/apertiumchill.py           55     41    25%
modules/apy.py                    240     56    77%
modules/away.py                    36      5    86%
modules/botfun.py                  17      5    71%
modules/botsnack.py                69     48    30%
modules/calc.py                    59     20    66%
modules/choose.py                  13      7    46%
modules/clock.py                  283    105    63%
modules/codepoints.py              96     83    14%
modules/commit.py                   9      1    89%
modules/eightball.py               15      1    93%
modules/eleda.py                   89     71    20%
modules/ethnologue.py              99     69    30%
modules/fcc.py                     19     12    37%
modules/fs_quotes.py               59     32    46%
modules/gci.py                    119     86    28%
modules/git.py                    376    326    13%
modules/greeting.py               103     32    69%
modules/head.py                   179     58    68%
modules/hs.py                      41      2    95%
modules/info.py                    55     47    15%
modules/iso639.py                 123     23    81%
modules/linx.py                    14      8    43%
modules/logger.py                  23      7    70%
modules/mailing_list.py           131    103    21%
modules/more.py                    81      7    91%
modules/noexceptions.py            72     37    49%
modules/nsfw.py                    10      1    90%
modules/pester.py                 108     90    17%
modules/ping.py                    58     37    36%
modules/queue.py                  219     64    71%
modules/reload.py                  39     26    33%
modules/remind.py                 101     43    57%
modules/sasl.py                    80     42    48%
modules/search.py                  76     39    49%
modules/seen.py                    50     37    26%
modules/sfissues.py                17     13    24%
modules/startup.py                 52     41    21%
modules/svnpoller.py              189    151    20%
modules/tell.py                   210    132    37%
modules/urbandict.py               36      5    86%
modules/weirdfun.py                32     20    38%
modules/wiki_count.py              94     79    16%
modules/wikipedia.py               44      8    82%
modules/wiktionary.py             163     61    63%
phenny/opt/__init__.py              0      0   100%
proto.py                           35     13    63%
tools.py                          185     69    63%
web.py                            115     42    63%
wiki.py                           108     16    85%
---------------------------------------------------
TOTAL                            5427   2833    48%
nose.plugins.cover: ERROR: TOTAL Coverage did not reach minimum required: 50%
```

Waiting for #442 