### PR TITLE
Fix the URL generated when no arguments is passed to .logs

### DIFF
--- a/modules/apertium_wiki.py
+++ b/modules/apertium_wiki.py
@@ -76,7 +76,7 @@ def logs(phenny, input):
 
     if not date_query:
         # .logs
-        phenny.say("Log at {0}.log".format(endpoints['log']))
+        phenny.say("Log at {0}".format(endpoints['log']))
     elif "today" in date_query:
         # .logs today
         phenny.say("Log at {0}{1}.log".format(endpoints['log'], dt.date.today()))

--- a/modules/test/test_apertium_wiki.py
+++ b/modules/test/test_apertium_wiki.py
@@ -136,3 +136,11 @@ class TestApertiumWiki(unittest.TestCase):
             day_query = str(date(9999, 99, 99))
             out_check = day_query in out
         self.assertFalse(string_check and out_check)
+
+    def test_logs_no_date(self):
+        self.input.group = lambda x: [None, None][x]
+        apertium_wiki.logs(self.phenny, self.input)
+        out = self.phenny.say.call_args[0][0]
+        string_check = ("Log at " in out) and (not out.endswith(".log"))
+
+        self.assertTrue(string_check)

--- a/modules/test/test_apertium_wiki.py
+++ b/modules/test/test_apertium_wiki.py
@@ -141,6 +141,5 @@ class TestApertiumWiki(unittest.TestCase):
         self.input.group = lambda x: [None, None][x]
         apertium_wiki.logs(self.phenny, self.input)
         out = self.phenny.say.call_args[0][0]
-        string_check = ("Log at " in out) and (not out.endswith(".log"))
 
-        self.assertTrue(string_check)
+        self.assertTrue(('Log at ' in out) and (not out.endswith('.log')))


### PR DESCRIPTION
Fixes #474
Remove the excess .log added to the end of the URL when .logs is
used with no arguments.