### PR TITLE
Update README to change name to Begiak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# phenny
+# begiak
 [![Build Status](https://travis-ci.org/apertium/phenny.png?branch=master)](https://travis-ci.org/apertium/phenny)
 [![Coverage Status](https://coveralls.io/repos/github/apertium/phenny/badge.svg?branch=master)](https://coveralls.io/github/apertium/phenny?branch=master)
 
-This is phenny, a Python IRC bot. Originally written by Sean B. Palmer, it has
-been ported to Python3.
+This is begiak, a Python IRC bot.
+Originally written by Sean B. Palmer as "phenny", it has been ported to Python 3.
 
 This version comes with many new modules, IPv6 support, TLS support, and unit
 tests.
@@ -19,7 +19,7 @@ core modules have been ported, removed, or replaced.
 ## Installation
 1. Run `./phenny` - this creates a default config file
 2. Edit `~/.phenny/default.py`
-3. Run `./phenny` - this now runs phenny with your settings
+3. Run `./phenny` - this now runs begiak with your settings
 
 Enjoy!
 
@@ -30,3 +30,4 @@ the tests, simply run `nosetests3`.
 ## Authors
 * Sean B. Palmer, http://inamidst.com/sbp/
 * mutantmonkey, http://mutantmonkey.in
+* Various Apertium developers


### PR DESCRIPTION
We don't call it Phenny, we call it Begiak. The README should reflect this