### PR TITLE
Make commands case-insensitive

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -144,7 +144,7 @@ class Phenny(irc.Bot):
             keys.append(regexp)
 
         for key in keys:
-            key = re.compile(key)
+            key = re.compile(key, re.IGNORECASE)
             commands.setdefault(key, []).append(func)
 
     def bind_command(self, module, name, func):


### PR DESCRIPTION
Before this commit, only .choose a b worked.
Now, .ChOoSe a b is just fine.