### PR TITLE
Fix for issue #491

### DIFF
--- a/modules/clock.py
+++ b/modules/clock.py
@@ -190,7 +190,16 @@ def scrape_wiki_time_zone_abbreviations(doc):
                 else:
                     name = cell.find('a').text
             elif column == column_names.index('UTC offset'):
-                offset = cell.find('a').text[3:]
+                # There was an issue with crashes, caused by
+                # cells not containing links. Attempting
+                # to fix through testing whether cell has
+                # a link inside of it, otherwise just get text.
+
+                if len(cell.findall('a')) == 0:
+                    offset = cell.text[3:]
+                else:
+                    offset = cell.find('a').text[3:]
+                
                 offset = offset.replace('−', '-') # hyphen -> minus
 
                 if offset.find(':') > 0:

--- a/modules/clock.py
+++ b/modules/clock.py
@@ -186,7 +186,7 @@ def scrape_wiki_time_zone_abbreviations(doc):
                 # a link inside of it, otherwise just get text.
 
                 if len(cell.findall('a')) == 0:
-                    name = cell.html.text
+                    name = cell.text
                 else:
                     name = cell.find('a').text
             elif column == column_names.index('UTC offset'):

--- a/modules/clock.py
+++ b/modules/clock.py
@@ -236,8 +236,8 @@ def scrape_wiki_tz_database_time_zones(doc):
         for cell in row.findall('td'):
             # issue with finding the column, fixing
             # Used regex as mentioned in the pull-request review
-            r = re.compile("(^| )TZ( |$)")
-            if column == column_names.index(list(filter(r.match, column_names)[0]):
+            current_regex = re.compile("(^| )TZ( |$)")
+            if column == column_names.index(list(filter(current_regex.match, column_names))[0]):
                 text = cell.find('a').text
                 text = text.replace('_', ' ').replace('−', '-')
 

--- a/modules/clock.py
+++ b/modules/clock.py
@@ -180,7 +180,15 @@ def scrape_wiki_time_zone_abbreviations(doc):
             if column == column_names.index('Abbr.'):
                 code = cell.text
             elif column == column_names.index('Name'):
-                name = cell.find('a').text
+                # There was an issue with crashes, caused by
+                # cells not containing links. Attempting
+                # to fix through testing whether cell has
+                # a link inside of it, otherwise just get text.
+
+                if len(cell.findall('a')) == 0:
+                    name = cell.html.text
+                else:
+                    name = cell.find('a').text
             elif column == column_names.index('UTC offset'):
                 offset = cell.find('a').text[3:]
                 offset = offset.replace('−', '-') # hyphen -> minus

--- a/modules/clock.py
+++ b/modules/clock.py
@@ -199,7 +199,7 @@ def scrape_wiki_time_zone_abbreviations(doc):
                     offset = cell.text[3:]
                 else:
                     offset = cell.find('a').text[3:]
-                
+
                 offset = offset.replace('−', '-') # hyphen -> minus
 
                 if offset.find(':') > 0:
@@ -236,12 +236,14 @@ def scrape_wiki_tz_database_time_zones(doc):
         column = 0
 
         for cell in row.findall('td'):
-            if column == column_names.index('TZ'):
+            # issue with finding the column, fixing
+            if column == column_names.index('TZ database name'):
                 text = cell.find('a').text
                 text = text.replace('_', ' ').replace('−', '-')
 
                 name = text.split('/')[-1]
-            elif column == column_names.index('UTC offset'):
+            # used to be UTC offset but I think complete names are necessary
+            elif column == column_names.index('UTC offset ±hh:mm'):
                 text = cell.find('a').text
                 text = text.replace('_', ' ').replace('−', '-')
 


### PR DESCRIPTION
## Summary: a response to #491 (clock module crash)

### Issue Identification
Certain sections of the wikipedia page for timezones do not have a link for the time zone (for example, the first two rows displayed in the image below).

![timezones](https://user-images.githubusercontent.com/46852717/70487907-735efc00-1abc-11ea-8bc7-ea7cb613f122.PNG)

### Resolution
After consulting the guide for HTML scraping at http://effbot.org/zone/element-index.htm#documentation, I added a failsafe for the cases in which there is no link. Since the footnotes are made using `<sub>`, and the `.text` function returns the string before any sub-elements, this should fix the issue mentioned above.

Make sure to test if this works.
