### PR TITLE
Fix test to avoid rounding error in weather module

### DIFF
--- a/modules/test/test_weather.py
+++ b/modules/test/test_weather.py
@@ -39,7 +39,7 @@ class TestWeather(unittest.TestCase):
             ("Vilnius", (54.7, 25.3)),
 
             ('Blacksburg, VA', (37.2, -80.4)),
-            ('Granger, IN', (41.7, -86.1)),
+            ('Granger, IN', (41.8, -86.1)),
         ]
 
         for query, expected in locations:


### PR DESCRIPTION
Apparently the failing tests in the weather module were due to `41.7` and `41.75` not being approximately equal.