### PR TITLE
Add missing commas - Attempts to fix #485

### DIFF
--- a/apertium_wikistats_bot.py
+++ b/apertium_wikistats_bot.py
@@ -39,13 +39,6 @@ fileStatTypeMapping = {
 def formatNumberThousands(number):
     return '{:,}'.format(number)
 
-def isInt(var):
-    try:
-        int(var)
-        return True
-    except ValueError:
-        return False
-
 def getStats(rawStats, monoLang):
     if not rawStats:
         return {}
@@ -64,11 +57,8 @@ def getStats(rawStats, monoLang):
                 countType = splitFilePath[1] + ' ' + wikiKey
             revisionInfo = (githubCommitUrl % (statName, stat['sha'], filePath), stat['last_author'], stat['sha'][:6])
 
-            statValue = stat['value']
-
-            if isInt(statValue):
-                statValue = int(statValue)
-                statValue = formatNumberThousands(statValue)
+            statValue = int(stat['value'])
+            statValue = formatNumberThousands(statValue)
             
             fileCounts[countType] = (statValue, revisionInfo, githubBlobUrl % (statName, filePath))
     return fileCounts

--- a/apertium_wikistats_bot.py
+++ b/apertium_wikistats_bot.py
@@ -35,6 +35,10 @@ fileStatTypeMapping = {
     'Transfer': {'Rules': 'rules', 'Macros': 'macros'}
 }
 
+# https://docs.python.org/3.8/library/string.html#format-examples
+def formatNumberThousands(number):
+    return '{:,}'.format(number)
+
 def getStats(rawStats, monoLang):
     if not rawStats:
         return {}
@@ -52,7 +56,11 @@ def getStats(rawStats, monoLang):
             if not monoLang:
                 countType = splitFilePath[1] + ' ' + wikiKey
             revisionInfo = (githubCommitUrl % (statName, stat['sha'], filePath), stat['last_author'], stat['sha'][:6])
-            fileCounts[countType] = (stat['value'], revisionInfo, githubBlobUrl % (statName, filePath))
+
+            statValue = stat['value']
+            statValue = formatNumberThousands(statValue)
+
+            fileCounts[countType] = (statValue, revisionInfo, githubBlobUrl % (statName, filePath))
     return fileCounts
 
 def getJSONFromStatsService(lang):

--- a/apertium_wikistats_bot.py
+++ b/apertium_wikistats_bot.py
@@ -39,6 +39,13 @@ fileStatTypeMapping = {
 def formatNumberThousands(number):
     return '{:,}'.format(number)
 
+def isInt(var):
+    try:
+        int(var)
+        return True
+    except ValueError:
+        return False
+
 def getStats(rawStats, monoLang):
     if not rawStats:
         return {}
@@ -58,8 +65,11 @@ def getStats(rawStats, monoLang):
             revisionInfo = (githubCommitUrl % (statName, stat['sha'], filePath), stat['last_author'], stat['sha'][:6])
 
             statValue = stat['value']
-            statValue = formatNumberThousands(statValue)
 
+            if isInt(statValue):
+                statValue = int(statValue)
+                statValue = formatNumberThousands(statValue)
+            
             fileCounts[countType] = (statValue, revisionInfo, githubBlobUrl % (statName, filePath))
     return fileCounts
 


### PR DESCRIPTION
This attempts to fix #485.

I created a helper function `formatNumberThousands()`  formats the numbers with the thousands separator.
This is used in the `getStats()` function to format the numbers with the `,`.