### PR TITLE
Update weather module tests - fix #514

### DIFF
--- a/modules/test/test_weather.py
+++ b/modules/test/test_weather.py
@@ -17,8 +17,8 @@ class TestWeather(unittest.TestCase):
     @catch_timeout
     def test_locations(self):
         def check_location(result, expected):
-            self.assertAlmostEqual(result[0], expected[0], places=1)
-            self.assertAlmostEqual(result[1], expected[1], places=1)
+            self.assertAlmostEqual(result[0], expected[0], delta=0.07)
+            self.assertAlmostEqual(result[1], expected[1], delta=0.07)
 
         locations = [
             ('92121', (32.9, -117.2)),


### PR DESCRIPTION
According to [this page](https://en.wikipedia.org/wiki/Decimal_degrees) about _Decimal Degrees_ on _Wikipedia_, `0.01 decimal degress` corresponds to approximately `1.11 km`.
Using  `0.07` for `delta`, would correctly assert coordinates which are `7.77km` away from the "true coordinates".

In my opinion, this seems reasonable to assert if the coordinates are inside a city.

I have changed the `assertAlmostEqual` function parameters to use a `delta` of 0.07 instead of a number of decimal places.
