### PR TITLE
Fix apy modules tests - Re: #516

### DIFF
--- a/modules/apy.py
+++ b/modules/apy.py
@@ -107,7 +107,7 @@ def apertium_translate(phenny, input):
                 translated = web.decode(translate(phenny, translated, input_lang, output_lang))
             except GrumbleError as err:
                 phenny.say('{:s}-{:s}: {:s}'.format(input_lang, output_lang, str(err)))
-                return
+                return SYNTAX_ERROR
         phenny.reply(web.decode(translated))
 
 apertium_translate.name = 't'

--- a/modules/apy.py
+++ b/modules/apy.py
@@ -101,6 +101,7 @@ def apertium_translate(phenny, input):
             if input_lang == output_lang:
                 #raise GrumbleError('Stop trying to confuse me! Pick different languages ;)')
                 phenny.say('Stop trying to confuse me! Pick different languages ;)')
+                return SYNTAX_ERROR
             
             # TODO: Remove this try/except block? web.decode doesn't seem to raise any GrumbleError's
             try:

--- a/modules/apy.py
+++ b/modules/apy.py
@@ -380,7 +380,8 @@ def apertium_perword(phenny, input):
     # validate requested functions
     funcs = cmd.group(2).split(' ')
     if not set(funcs) <= valid_funcs:
-        raise GrumbleError('The requested functions must be from the set {:s}.'.format(str(valid_funcs)))
+        phenny.say('The requested functions must be from the set {:s}.'.format(str(valid_funcs)))
+        return Status.KEYWORD_ERROR
 
     opener = urllib.request.build_opener()
     opener.addheaders = headers

--- a/modules/apy.py
+++ b/modules/apy.py
@@ -106,7 +106,7 @@ def apertium_translate(phenny, input):
             if input_lang == output_lang:
                 #raise GrumbleError('Stop trying to confuse me! Pick different languages ;)')
                 phenny.say('Stop trying to confuse me! Pick different languages ;)')
-                return Status.SYNTAX_ERROR
+                return Status.ENUM_ERROR
             
             # TODO: Remove this try/except block? web.decode doesn't seem to raise any GrumbleError's
             try:

--- a/modules/apy.py
+++ b/modules/apy.py
@@ -23,8 +23,6 @@ headers = [(
 Apy_errorData = 'Sorry, Apertium APy did not return any data.'
 langRE = r'[a-z]{2,3}(?:_[A-Za-z]+)?'
 
-SYNTAX_ERROR = 1
-
 class Status(IntEnum):
     OK = 0
     KEYWORD_ERROR = 1
@@ -44,7 +42,6 @@ def strict_check(pattern, string, function):
         error = 'Usage: {}'.format(function.example)
 
     return string, error
-
 
 def handle_error(error):
     response = error.read()

--- a/modules/apy.py
+++ b/modules/apy.py
@@ -22,6 +22,7 @@ headers = [(
 Apy_errorData = 'Sorry, Apertium APy did not return any data.'
 langRE = r'[a-z]{2,3}(?:_[A-Za-z]+)?'
 
+SYNTAX_ERROR = 1
 
 def strict_check(pattern, string, function):
     error = ''
@@ -85,11 +86,12 @@ def apertium_translate(phenny, input):
     
     if line_error:
         phenny.say(line_error)
-        return
+        return SYNTAX_ERROR
 
     if (len(line.group(2)) > 350) and (not input.admin):
         #raise GrumbleError('Phrase must be under 350 characters.')
         phenny.say('Phrase must be under 350 characters.')
+        return SYNTAX_ERROR
 
     blocks = line.group(1).split(' ')
     for block in blocks:
@@ -183,7 +185,7 @@ def apertium_analyse(phenny, input):
 
     if cmd_error:
         phenny.say(cmd_error)
-        return
+        return SYNTAX_ERROR
 
     opener = urllib.request.build_opener()
     opener.addheaders = headers
@@ -214,7 +216,7 @@ def apertium_generate(phenny, input):
 
     if cmd_error:
         phenny.say(cmd_error)
-        return
+        return SYNTAX_ERROR
 
     opener = urllib.request.build_opener()
     opener.addheaders = headers
@@ -246,7 +248,7 @@ def apertium_identlang(phenny, input):
 
     if text_error:
         phenny.say(text_error)
-        return
+        return SYNTAX_ERROR
 
     opener = urllib.request.build_opener()
     opener.addheaders = headers
@@ -340,7 +342,7 @@ def apertium_calccoverage(phenny, input):
 
     if cmd_error:
         phenny.say(cmd_error)
-        return
+        return SYNTAX_ERROR
 
     opener = urllib.request.build_opener()
     opener.addheaders = headers
@@ -367,7 +369,7 @@ def apertium_perword(phenny, input):
 
     if cmd_error:
         phenny.say(cmd_error)
-        return
+        return SYNTAX_ERROR
 
     # validate requested functions
     funcs = cmd.group(2).split(' ')

--- a/modules/apy.py
+++ b/modules/apy.py
@@ -12,7 +12,7 @@ from tools import GrumbleError
 from modules import more
 import operator
 from humanize import naturaldelta
-from enum import IntEnum
+from enum import Enum
 
 headers = [(
     'User-Agent', 'Mozilla/5.0' +
@@ -23,7 +23,7 @@ headers = [(
 Apy_errorData = 'Sorry, Apertium APy did not return any data.'
 langRE = r'[a-z]{2,3}(?:_[A-Za-z]+)?'
 
-class Status(IntEnum):
+class Status(Enum):
     OK = 0
     KEYWORD_ERROR = 1
     ENUM_ERROR = 2

--- a/modules/test/test_apy.py
+++ b/modules/test/test_apy.py
@@ -102,7 +102,7 @@ class TestAPy(unittest.TestCase):
         self.check_error([self.texts['spa'], 'spa ' + self.texts['spa'], 'spa-eng'],
                               apy.apertium_translate, apy.Status.SYNTAX_ERROR)
         self.check_error(['en-en Translate to the same language?'],
-                              apy.apertium_translate, apy.Status.SYNTAX_ERROR, 'self-translation')
+                              apy.apertium_translate, apy.Status.ENUM_ERROR, 'self-translation')
         self.reset_mocks(self.phenny, mock_open, mock_handle)
 
         # non-existent language with actual language

--- a/modules/test/test_apy.py
+++ b/modules/test/test_apy.py
@@ -55,13 +55,13 @@ class TestAPy(unittest.TestCase):
                                    msg='No exception raised for {:s}!'.format(reason)):
                 name.__call__(self.phenny, self.input)
 
-    def check_syntax_error(self, bad_list, name, reason=None):
+    def check_error(self, bad_list, name, error, reason=None):
         if not reason:
             reason = 'invalid input to {:s}'.format(name.__name__)
         for inp in bad_list:
             self.input.group.return_value = inp
             function_return_val = name.__call__(self.phenny, self.input)
-            self.assertEqual(function_return_val, apy.SYNTAX_ERROR, msg='No syntax error returned for {:s}!'.format(reason))
+            self.assertEqual(function_return_val, error, msg='No syntax error returned for {:s}!'.format(reason))
 
     def test_translate_langs(self, mock_open):
         # single language
@@ -97,10 +97,10 @@ class TestAPy(unittest.TestCase):
         self.reset_mocks(self.phenny, mock_open, mock_handle)
 
         # bad input
-        self.check_syntax_error([self.texts['spa'], 'spa ' + self.texts['spa'], 'spa-eng'],
-                              apy.apertium_translate)
-        self.check_syntax_error(['en-en Translate to the same language?'],
-                              apy.apertium_translate, 'self-translation')
+        self.check_error([self.texts['spa'], 'spa ' + self.texts['spa'], 'spa-eng'],
+                              apy.apertium_translate, apy.Status.SYNTAX_ERROR)
+        self.check_error(['en-en Translate to the same language?'],
+                              apy.apertium_translate, apy.Status.SYNTAX_ERROR, 'self-translation')
         self.reset_mocks(self.phenny, mock_open, mock_handle)
 
         # non-existent language with actual language
@@ -119,8 +119,9 @@ class TestAPy(unittest.TestCase):
 
         # restricted length for non-admin
         self.input.admin = False
-        self.check_syntax_error(['eng-spa ' + self.texts['eng_long']],
-                              apy.apertium_translate, 'long non-admin translation!')
+        self.check_error(['eng-spa ' + self.texts['eng_long']],
+                              apy.apertium_translate, apy.Status.SYNTAX_ERROR,
+                              'long non-admin translation!')
         self.reset_mocks(self.phenny, mock_open)
 
         # non-restricted length for admin
@@ -197,8 +198,8 @@ class TestAPy(unittest.TestCase):
         self.reset_mocks(mock_open, mock_addmsgs)
 
         # bad input
-        self.check_syntax_error([' '.join(words), 'eng'], apy.apertium_analyse)
-        self.check_syntax_error([' '.join(words), 'eng'], apy.apertium_generate)
+        self.check_error([' '.join(words), 'eng'], apy.apertium_analyse, apy.Status.SYNTAX_ERROR)
+        self.check_error([' '.join(words), 'eng'], apy.apertium_generate, apy.Status.SYNTAX_ERROR)
 
     @mock.patch('modules.apy.more.add_messages')
     def test_identlang(self, mock_addmsgs, mock_open):
@@ -232,7 +233,7 @@ class TestAPy(unittest.TestCase):
         self.reset_mocks(self.phenny, mock_open)
 
         # bad input
-        self.check_syntax_error(['eng', self.texts['eng'], 'eng-spa'], apy.apertium_calccoverage)
+        self.check_error(['eng', self.texts['eng'], 'eng-spa'], apy.apertium_calccoverage, apy.Status.SYNTAX_ERROR)
 
     def test_perword(self, mock_open):
         # valid perword functions
@@ -258,5 +259,6 @@ class TestAPy(unittest.TestCase):
         # bad input
         self.check_exceptions(['fra (tagger nonfunc) word'], apy.apertium_perword,
                               'invalid perword function')
-        self.check_syntax_error(['fra', 'fra (tagger)', '(tagger)', 'fra word',
-                               '(tagger morph) word'], apy.apertium_perword)
+        self.check_error(['fra', 'fra (tagger)', '(tagger)', 'fra word',
+                               '(tagger morph) word'], apy.apertium_perword,
+                               apy.Status.SYNTAX_ERROR)

--- a/modules/test/test_apy.py
+++ b/modules/test/test_apy.py
@@ -58,10 +58,12 @@ class TestAPy(unittest.TestCase):
     def check_error(self, bad_list, name, error, reason=None):
         if not reason:
             reason = 'invalid input to {:s}'.format(name.__name__)
+        if not isinstance(error, apy.Status):
+            raise ValueError('Parameter error must be a Status.')
         for inp in bad_list:
             self.input.group.return_value = inp
             function_return_val = name.__call__(self.phenny, self.input)
-            self.assertEqual(function_return_val, error, msg='No syntax error returned for {:s}!'.format(reason))
+            self.assertEqual(function_return_val, error, msg='No {:s} returned for {:s}!'.format(error.name, reason))
 
     def test_translate_langs(self, mock_open):
         # single language

--- a/modules/test/test_apy.py
+++ b/modules/test/test_apy.py
@@ -46,15 +46,6 @@ class TestAPy(unittest.TestCase):
         for moc in mocks:
             moc.reset_mock()
 
-    def check_exceptions(self, bad_list, name, reason=None):
-        if not reason:
-            reason = 'invalid input to {:s}'.format(name.__name__)
-        for inp in bad_list:
-            self.input.group.return_value = inp
-            with self.assertRaises(GrumbleError,
-                                   msg='No exception raised for {:s}!'.format(reason)):
-                name.__call__(self.phenny, self.input)
-
     def check_error(self, bad_list, name, error, reason=None):
         if not reason:
             reason = 'invalid input to {:s}'.format(name.__name__)
@@ -259,8 +250,8 @@ class TestAPy(unittest.TestCase):
         self.reset_mocks(self.phenny, mock_open)
 
         # bad input
-        self.check_exceptions(['fra (tagger nonfunc) word'], apy.apertium_perword,
-                              'invalid perword function')
+        self.check_error(['fra (tagger nonfunc) word'], apy.apertium_perword,
+                            apy.Status.KEYWORD_ERROR, 'invalid perword function')
         self.check_error(['fra', 'fra (tagger)', '(tagger)', 'fra word',
                                '(tagger morph) word'], apy.apertium_perword,
                                apy.Status.SYNTAX_ERROR)

--- a/modules/test/test_apy.py
+++ b/modules/test/test_apy.py
@@ -55,6 +55,14 @@ class TestAPy(unittest.TestCase):
                                    msg='No exception raised for {:s}!'.format(reason)):
                 name.__call__(self.phenny, self.input)
 
+    def check_syntax_error(self, bad_list, name, reason=None):
+        if not reason:
+            reason = 'invalid input to {:s}'.format(name.__name__)
+        for inp in bad_list:
+            self.input.group.return_value = inp
+            function_return_val = name.__call__(self.phenny, self.input)
+            self.assertEqual(function_return_val, apy.SYNTAX_ERROR, msg='No syntax error returned for {:s}!'.format(reason))
+
     def test_translate_langs(self, mock_open):
         # single language
         self.input.group.return_value = 'eng-spa ' + self.texts['eng']
@@ -89,9 +97,9 @@ class TestAPy(unittest.TestCase):
         self.reset_mocks(self.phenny, mock_open, mock_handle)
 
         # bad input
-        self.check_exceptions([self.texts['spa'], 'spa ' + self.texts['spa'], 'spa-eng'],
+        self.check_syntax_error([self.texts['spa'], 'spa ' + self.texts['spa'], 'spa-eng'],
                               apy.apertium_translate)
-        self.check_exceptions(['en-en Translate to the same language?'],
+        self.check_syntax_error(['en-en Translate to the same language?'],
                               apy.apertium_translate, 'self-translation')
         self.reset_mocks(self.phenny, mock_open, mock_handle)
 
@@ -111,7 +119,7 @@ class TestAPy(unittest.TestCase):
 
         # restricted length for non-admin
         self.input.admin = False
-        self.check_exceptions(['eng-spa ' + self.texts['eng_long']],
+        self.check_syntax_error(['eng-spa ' + self.texts['eng_long']],
                               apy.apertium_translate, 'long non-admin translation!')
         self.reset_mocks(self.phenny, mock_open)
 
@@ -189,8 +197,8 @@ class TestAPy(unittest.TestCase):
         self.reset_mocks(mock_open, mock_addmsgs)
 
         # bad input
-        self.check_exceptions([' '.join(words), 'eng'], apy.apertium_analyse)
-        self.check_exceptions([' '.join(words), 'eng'], apy.apertium_generate)
+        self.check_syntax_error([' '.join(words), 'eng'], apy.apertium_analyse)
+        self.check_syntax_error([' '.join(words), 'eng'], apy.apertium_generate)
 
     @mock.patch('modules.apy.more.add_messages')
     def test_identlang(self, mock_addmsgs, mock_open):
@@ -224,7 +232,7 @@ class TestAPy(unittest.TestCase):
         self.reset_mocks(self.phenny, mock_open)
 
         # bad input
-        self.check_exceptions(['eng', self.texts['eng'], 'eng-spa'], apy.apertium_calccoverage)
+        self.check_syntax_error(['eng', self.texts['eng'], 'eng-spa'], apy.apertium_calccoverage)
 
     def test_perword(self, mock_open):
         # valid perword functions
@@ -250,5 +258,5 @@ class TestAPy(unittest.TestCase):
         # bad input
         self.check_exceptions(['fra (tagger nonfunc) word'], apy.apertium_perword,
                               'invalid perword function')
-        self.check_exceptions(['fra', 'fra (tagger)', '(tagger)', 'fra word',
+        self.check_syntax_error(['fra', 'fra (tagger)', '(tagger)', 'fra word',
                                '(tagger morph) word'], apy.apertium_perword)


### PR DESCRIPTION
This pull request attempts to fix issue #516.

Two changes were made:
1. In the apy module a specific value stored in the constant `SYNTAX_ERROR` is returned if a syntax error occurred. This change was made so that several functions in this module can be tested again. (Related to changes in #504)
2. A new function `check_syntax_error` was created to test if a function returns the appropriate `SYNTAX_ERROR` code.

Althought this is not a very elegant solution it should allow us to test for any problems in this module when changes occur, while a more robust solution with maybe more specific exceptions isn't implemented.

