### PR TITLE
scrape ISO 639 codes from single source

### DIFF
--- a/modules/ethnologue.py
+++ b/modules/ethnologue.py
@@ -20,6 +20,20 @@ def shorten_num(n):
         return '{}M'.format(str(round(n/1000000, 1)).rstrip('0').rstrip('.'))
 
 def scrape_ethnologue_codes(phenny):
+    data = {}
+
+    def scrape_ethnologue_code(doc):
+        for e in doc.find_class('views-field-field-iso-639-3'):
+            code = e.find('div/a').text
+            name = e.find('div/a').attrib['title']
+            data[code] = name
+
+    base_url = 'https://www.ethnologue.com/browse/codes/'
+    for letter in ascii_lowercase:
+        web.with_scraped_page(base_url + letter)(scrape_ethnologue_code)()
+    phenny.ethno_data = data
+
+def scrape_iso_codes(phenny):
     # see https://iso639-3.sil.org/code_tables/download_tables
     # for more information
     iso = {}
@@ -50,7 +64,7 @@ def scrape_ethnologue_codes(phenny):
 
 def write_ethnologue_codes(phenny, raw=None):
     if raw is None or raw.admin:
-        scrape_ethnologue_codes(phenny)
+        scrape_iso_codes(phenny)
         logger.debug('Ethnologue iso-639 code fetch successful')
         if raw:
             phenny.say('Ethnologue iso-639 code fetch successful')
@@ -137,4 +151,4 @@ ethnologue.example = '.ethnologue khk'
 ethnologue.priority = 'low'
 
 def setup(phenny):
-    scrape_ethnologue_codes(phenny)
+    scrape_iso_codes(phenny)

--- a/modules/iso639.py
+++ b/modules/iso639.py
@@ -139,7 +139,13 @@ def scrape_wiki_codes_convert(doc):
 def refresh_database(phenny, raw=None):
     if raw.admin or raw is None:
         ethnologue.write_ethnologue_codes(phenny)
+        # phenny.iso_data = scrape_wiki_codes()
+        # phenny.iso_data.update(phenny.ethno_data)
         phenny.say('ISO code database successfully written')
+
+        # phenny.iso_conversion_data = scrape_wiki_codes_convert()
+        # phenny.say('ISO conversion db successfully written')
+
     else:
         phenny.say('Only admins can execute that command!')
 
@@ -154,7 +160,7 @@ def thread_check(phenny, raw):
 def setup(phenny):
     # populate ethnologue codes
     ethnologue.setup(phenny)
-    
+
     # phenny.iso_data = scrape_wiki_codes()
     # phenny.iso_data.update(phenny.ethno_data)
 

--- a/modules/iso639.py
+++ b/modules/iso639.py
@@ -70,6 +70,72 @@ def iso639(phenny, input):
 
     phenny.say(response)
 
+def scrape_wiki_codes():
+    data = {}
+
+    base_url = 'https://en.wikipedia.org/wiki/List_of_ISO_639'
+    scrape_wiki_codes_1(data)
+    scrape_wiki_codes_2(data)
+
+    return data
+
+@web.with_scraped_page('https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes')
+def scrape_wiki_codes_1(doc, data):
+    table = doc.find_class('wikitable')[0]
+    for row in table.find('tbody').findall('tr')[1:]:
+        name = etree.tostring(row.findall('td')[2]).decode('utf-8')
+        name = etree.fromstring(name[name.find('<a'):name.find('</a>')+4]).text
+
+        code = etree.tostring(row.findall('td')[4]).decode('utf-8')
+        code = etree.fromstring(code[code.find('<a'):code.find('</a>')+4]).text
+
+        data[code] = name
+
+@web.with_scraped_page('https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes')
+def scrape_wiki_codes_2(doc, data):
+    table = doc.find_class('wikitable')[0]
+    for row in table.find('tbody').findall('tr')[1:]:
+        name = etree.tostring(row.findall('td')[4]).decode('utf-8')
+
+        if '<a' in name:
+            name = etree.fromstring(name[name.find('<a'):name.find('</a>')+4]).text
+        else:
+            continue
+
+        code_list = []
+        code1 = row.findall('td')[0].text
+        code = etree.tostring(row.findall('td')[0]).decode('utf-8')
+        code = etree.fromstring(code[code.find('<a'):code.find('</a>')+4]).text
+
+        if code1 != None:
+            code_list = code1.split(' ')
+            code_list.append(code)
+
+        if len(code_list) == 1:
+            code = code_list[0]
+        else:
+            for i in code_list:
+                if '*' in i:
+                    code = i.replace('*', '')
+                    break
+        data[code] = name
+
+@web.with_scraped_page('https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes')
+def scrape_wiki_codes_convert(doc):
+    data = {}
+    table = doc.find_class('wikitable')[0]
+    for row in table.find('tbody').findall('tr')[1:]:
+        iso3code = row.findall('td')[7].text
+        code = etree.tostring(row.findall('td')[4]).decode('utf-8')
+        code = etree.fromstring(code[code.find('<a'):code.find('</a>')+4]).text
+        if iso3code:
+            r = re.match("(.*) \+ .*", iso3code)
+            if r:
+                iso3code = r.group(1)
+            data[iso3code] = code
+            data[code] = iso3code
+    return data
+
 def refresh_database(phenny, raw=None):
     if raw.admin or raw is None:
         ethnologue.write_ethnologue_codes(phenny)
@@ -88,6 +154,13 @@ def thread_check(phenny, raw):
 def setup(phenny):
     # populate ethnologue codes
     ethnologue.setup(phenny)
+    
+    # phenny.iso_data = scrape_wiki_codes()
+    # phenny.iso_data.update(phenny.ethno_data)
+
+    # Conversion hash
+    # phenny.iso_conversion_data = scrape_wiki_codes_convert()
+
 
 iso639.name = 'iso639'
 #iso639.rule = (['iso639'], r'(.*)')

--- a/modules/test/test_iso639.py
+++ b/modules/test/test_iso639.py
@@ -34,7 +34,7 @@ class TestISO639(unittest.TestCase):
             'es': 'Spanish',
             'eng': 'English',
             'fra': 'French',
-            'deu': 'German, Standard',
+            'deu': 'German',
             'cat': 'Catalan',
             'spa': 'Spanish',
         }


### PR DESCRIPTION
I was messing around the Ethnologue scraping code in the hope of fixing the broken tests. I didn't manage that, but I did find a tab-separated text file containing the data that the `ethnologue` and `iso639` modules scrape. Anyway, this replaces scraping 26 Ethnologue pages and 3 Wikipedia pages with parsing a single text file, which seemed like an improvement.